### PR TITLE
Conda installation file and instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# nodebbs addition
+data/
+*.swp
+
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+# Installation
+Implementation of BGMD and MAPS, original work presented at Gesi et al 2024 - ICSE 2023
+
+install and activate environment:
+
+```bash
+conda install -f env.yml
+conda activate BGMD_MAPS
+```
+
+#Reimplementation
+Progress on a reimplementation of missing package BGMD can be found in the branch "redo-from-scratch"
+
 # Leveraging Feature Bias for Scalable Misprediction Explanation of Machine Learning Models
 This repository contains experimental data information and evaluation code for the paper "Leveraging Feature Bias for Scalable Misprediction Explanation of Machine Learning Models". Here, we present the details of the evaluation data and experimental results in Jupyter notebooks for easy reading.
 

--- a/env.yml
+++ b/env.yml
@@ -1,0 +1,12 @@
+name: BGMD_MAPS
+channels:
+  - defaults
+dependencies:
+  - python=3.8
+  - numpy
+  - pandas
+  - imbalanced-learn
+  - scikit-learn
+  - pip
+#  - pip:
+#    - -r requirements.txt # if needed


### PR DESCRIPTION
Copied over from the reimplementation branch "redo-from-scratch". Adds all necessary dependencies that are available through conda. 

Note that BGMD and MMD (Meta's EXPLAIN diagnoser) are not available on conda or pip. BGMD (helper function in Jupyter notebooks) is missing, MMD has a public repo: https://github.com/facebookresearch/mmd. 

We are not focusing on using the mmd package without being able to use BGMD.